### PR TITLE
fix: 按字节流偏移量排序 pageids，修复页序错乱

### DIFF
--- a/gen_cfg.py
+++ b/gen_cfg.py
@@ -33,6 +33,7 @@ class GenConfig:
         self.p_pagecount: str = config["p_pagecount"]
 
         self.pageids: list[str] = decode(self.page_info).split(",")
+        self.pageids.sort(key=lambda pid: int(pid.split("-")[3]))
         self.p_count: int = len(self.pageids)
         self.headnums: list[str] = self.header_info.replace('"', "").split(",")
 


### PR DESCRIPTION
doc88 服务器对某些文档的 pageInfo 页码分配有误，
按 offset 排序后页面按字节流自然顺序编号。